### PR TITLE
fix: examples/basic/package.json to reduce vulnerabilities

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "3.4.1",
+    "react-scripts": "3.4.2",
     "formik": "latest"
   },
   "prettier": {


### PR DESCRIPTION
### Description

In this PR, the version of "react-scripts" in the package.json file is being updated from "3.4.1" to "3.4.2".

Summary of changes:
- Update the version of "react-scripts" from "3.4.1" to "3.4.2" in package.json.