### PR TITLE
fix: examples/field-arrays/package.json to reduce vulnerabilities

### DIFF
--- a/examples/field-arrays/package.json
+++ b/examples/field-arrays/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "3.4.1",
+    "react-scripts": "3.4.2",
     "formik": "latest"
   },
   "prettier": {


### PR DESCRIPTION
### Description

In this pull request, the version of `react-scripts` in the `package.json` file is being updated from `3.4.1` to `3.4.2`.

Changes:
- Updated the version of `react-scripts` in the `dependencies` section of the `package.json` file from `3.4.1` to `3.4.2`.